### PR TITLE
fix: replace personal nginx host/upstream/cert values with placeholders

### DIFF
--- a/nginx-deployment-guide.md
+++ b/nginx-deployment-guide.md
@@ -1,5 +1,5 @@
 # Nginx配置更新指南
-# 为zhw-happynotes-img-uploader.dev.shukebeta.com添加SSE支持
+# 为happynotes-uploader.yourdomain.com添加SSE支持
 
 ## 🚨 关键变更说明
 
@@ -59,14 +59,14 @@ proxy_read_timeout 3600s;         # 1小时（保持长连接）
 
 ### 1. 备份现有配置
 ```bash
-sudo cp /etc/nginx/conf.d/zhw-happynotes-img-uploader.dev.shukebeta.com.conf \
-       /etc/nginx/conf.d/zhw-happynotes-img-uploader.dev.shukebeta.com.conf.backup
+sudo cp /etc/nginx/conf.d/happynotes-uploader.yourdomain.com.conf \
+       /etc/nginx/conf.d/happynotes-uploader.yourdomain.com.conf.backup
 ```
 
 ### 2. 更新配置文件
 将新配置内容替换到现有文件：
 ```bash
-sudo nano /etc/nginx/conf.d/zhw-happynotes-img-uploader.dev.shukebeta.com.conf
+sudo nano /etc/nginx/conf.d/happynotes-uploader.yourdomain.com.conf
 # 将上面的完整配置粘贴进去
 ```
 
@@ -86,7 +86,7 @@ sudo nginx -s reload
 ```bash
 curl -H "Accept: text/event-stream" \
      -H "Cache-Control: no-cache" \
-     https://zhw-happynotes-img-uploader.dev.shukebeta.com/api/progress/test123
+     https://happynotes-uploader.yourdomain.com/api/progress/test123
 ```
 
 期望结果：连接保持打开，而不是立即关闭。
@@ -95,29 +95,29 @@ curl -H "Accept: text/event-stream" \
 ```bash
 curl -X POST \
      -F "img=@test-image.jpg" \
-     https://zhw-happynotes-img-uploader.dev.shukebeta.com/api/upload
+     https://happynotes-uploader.yourdomain.com/api/upload
 ```
 
 ### 测试状态查询API
 ```bash
-curl https://zhw-happynotes-img-uploader.dev.shukebeta.com/api/upload/status/test123
+curl https://happynotes-uploader.yourdomain.com/api/upload/status/test123
 ```
 
 ## 📊 监控和日志
 
 ### 查看SSE连接日志
 ```bash
-tail -f /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.access.log | grep progress
+tail -f /var/log/nginx/happynotes-uploader.yourdomain.com.access.log | grep progress
 ```
 
 ### 查看上传日志
 ```bash
-tail -f /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.access.log | grep upload
+tail -f /var/log/nginx/happynotes-uploader.yourdomain.com.access.log | grep upload
 ```
 
 ### 查看错误日志
 ```bash
-tail -f /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.error.log
+tail -f /var/log/nginx/happynotes-uploader.yourdomain.com.error.log
 ```
 
 ## ⚠️ 注意事项
@@ -142,8 +142,8 @@ tail -f /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.error.log
 如果新配置有问题：
 ```bash
 # 快速回滚
-sudo cp /etc/nginx/conf.d/zhw-happynotes-img-uploader.dev.shukebeta.com.conf.backup \
-       /etc/nginx/conf.d/zhw-happynotes-img-uploader.dev.shukebeta.com.conf
+sudo cp /etc/nginx/conf.d/happynotes-uploader.yourdomain.com.conf.backup \
+       /etc/nginx/conf.d/happynotes-uploader.yourdomain.com.conf
 sudo nginx -s reload
 ```
 

--- a/nginx-updated-zhw-happynotes-img-uploader.conf
+++ b/nginx-updated-zhw-happynotes-img-uploader.conf
@@ -1,9 +1,9 @@
 server {
-    server_name zhw-happynotes-img-uploader.dev.shukebeta.com;
+    server_name happynotes-uploader.yourdomain.com;
     client_max_body_size 50M;  # 增加到50M以支持更大文件
 
-    access_log  /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.access.log;
-    error_log   /var/log/nginx/zhw-happynotes-img-uploader.dev.shukebeta.com.error.log;
+    access_log  /var/log/nginx/happynotes-uploader.yourdomain.com.access.log;
+    error_log   /var/log/nginx/happynotes-uploader.yourdomain.com.error.log;
 
     # 🆕 SSE进度推送专用配置 - 关键新增！
     location /api/progress/ {
@@ -19,7 +19,7 @@ server {
         proxy_send_timeout 60s;
         
         # 代理到后端
-        proxy_pass http://xps.shukebeta.eu.org:3000;
+        proxy_pass http://127.0.0.1:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
@@ -51,7 +51,7 @@ server {
         proxy_read_timeout 1800s;         # 30分钟
         
         # 代理配置
-        proxy_pass http://xps.shukebeta.eu.org:3000;
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Connection "";   # 不保持连接，每次上传新建
         proxy_set_header Host $host;
@@ -75,7 +75,7 @@ server {
 
     # 🆕 上传状态查询API
     location /api/upload/status/ {
-        proxy_pass http://xps.shukebeta.eu.org:3000;
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         proxy_set_header Host $host;
@@ -109,7 +109,7 @@ server {
             return 204;
         }
         
-        proxy_pass http://xps.shukebeta.eu.org:3000;
+        proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection keep-alive;
@@ -126,18 +126,18 @@ server {
 
     listen [::]:443 ssl; # managed by Certbot
     listen 443 ssl; # managed by Certbot
-    ssl_certificate /etc/letsencrypt/live/zhw-happynotes-img-uploader.dev.shukebeta.com/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/zhw-happynotes-img-uploader.dev.shukebeta.com/privkey.pem; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/happynotes-uploader.yourdomain.com/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/happynotes-uploader.yourdomain.com/privkey.pem; # managed by Certbot
     include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
 }
 
 server {
-    if ($host = zhw-happynotes-img-uploader.dev.shukebeta.com) {
+    if ($host = happynotes-uploader.yourdomain.com) {
         return 301 https://$host$request_uri;
     } # managed by Certbot
 
-    server_name zhw-happynotes-img-uploader.dev.shukebeta.com;
+    server_name happynotes-uploader.yourdomain.com;
     listen [::]:80;
     listen 80;
     return 404; # managed by Certbot


### PR DESCRIPTION
## What & why

`nginx-updated-zhw-happynotes-img-uploader.conf` was a live, Certbot-managed dump that hardcoded a real subdomain (`zhw-happynotes-img-uploader.dev.shukebeta.com`), a real upstream tunnel host (`xps.shukebeta.eu.org:3000`), and real letsencrypt cert/log paths — committed to a **public** repo. Its sibling `nginx-happynotes-uploader.conf` already uses placeholder values, so this file broke the project's own redistributable-template convention.

## Change

De-personalize the conf **and** its companion `nginx-deployment-guide.md` (which leaked the same hostname in ~13 spots — backup/edit/rollback conf paths, curl test URLs, log tails). Two substitutions, structure untouched:

- `zhw-happynotes-img-uploader.dev.shukebeta.com` → `happynotes-uploader.yourdomain.com`
- `xps.shukebeta.eu.org:3000` → `127.0.0.1:3000`

The Certbot-managed shape (`# managed by Certbot` markers, `/etc/letsencrypt/live/<placeholder>/…` layout) is preserved so the file remains a faithful example of a real certbot-managed config.

## Verification

`git grep "shukebeta" -- 'nginx*'` and `git grep "xps\.shukebeta"` both return no hits in tracked nginx conf/doc. Static conf/doc only — no build or runtime to exercise.

## Scope notes

- Out of scope, deliberately: `git@github.com:shukebeta/…` clone URLs (README/deploy — not a leak), `localhost,shukebeta.com` origin-suffix in tests/`.env.example` (legitimate fixture), and real DB hosts in `.env.production`/`.env.staging` (different artifact family — server-side env, warrants its own ticket).
- **History not scrubbed:** the introducing commit still lives in `master` history; rewriting public-repo history is destructive and out of scope for this ticket.

Closes #22
