### PR TITLE
fix: report incremental SSE upload progress via req data hook (#23)

### DIFF
--- a/src/routes/progressRoutes.js
+++ b/src/routes/progressRoutes.js
@@ -8,6 +8,8 @@ class ProgressManager {
     this.cleanupTimers = new Map();
     this.initialCleanupMs = options.initialCleanupMs ?? 30 * 60 * 1000;
     this.terminalCleanupMs = options.terminalCleanupMs ?? 60 * 1000;
+    this.networkProgressCeiling = options.networkProgressCeiling ?? 0.9;
+    this.progressThrottleMs = options.progressThrottleMs ?? 100;
     this.now = options.now || (() => Date.now());
     this.setTimer = options.setTimer || setTimeout;
     this.clearTimer = options.clearTimer || clearTimeout;
@@ -45,6 +47,33 @@ class ProgressManager {
       receivedBytes: 0,
       startTime: this.now(),
     }, { createIfMissing: true, cleanupMs: this.initialCleanupMs });
+  }
+
+  // Network-phase byte tracker: called per request-body chunk while the upload
+  // streams in. Maps received bytes onto the [0, networkProgressCeiling] band so
+  // progress animates during transfer instead of jumping 0 -> 0.9 -> 1.
+  // Broadcasts are throttled by progressThrottleMs (injectable now()) so a large
+  // body doesn't flood SSE clients; the eventual markProcessing() always lands
+  // the final 0.9 regardless of where the last throttled tick fell.
+  recordReceivedBytes(uploadId, receivedBytes) {
+    const upload = this.getUpload(uploadId);
+    if (!upload) {
+      return null;
+    }
+
+    upload.receivedBytes = receivedBytes;
+    if (upload.fileSize > 0) {
+      upload.progress = clampProgress((receivedBytes / upload.fileSize) * this.networkProgressCeiling);
+    }
+
+    const now = this.now();
+    upload.lastUpdate = now;
+    if (this.progressThrottleMs <= 0 || upload.lastBroadcast === undefined || now - upload.lastBroadcast >= this.progressThrottleMs) {
+      upload.lastBroadcast = now;
+      this.broadcastProgress(uploadId);
+    }
+
+    return upload;
   }
 
   markProcessing(uploadId, { fileSize, receivedBytes } = {}) {

--- a/src/upload/progressAwareUploader.js
+++ b/src/upload/progressAwareUploader.js
@@ -53,6 +53,10 @@ function createUploadMiddleware(config = {}, deps = {}) {
 
     if (activeProgressManager && queryUploadId) {
       activeProgressManager.startUpload(queryUploadId, { fileSize: contentLength });
+      // Multer/busboy attaches its own data listener on ctx.req (flowing mode),
+      // so this second listener sees the same body chunks and can report
+      // incremental transfer progress while Multer still streams to disk.
+      attachByteTracker(ctx.req, activeProgressManager, queryUploadId);
     }
 
     try {
@@ -128,6 +132,32 @@ function normalizeUploadId(value) {
 function parseContentLength(value) {
   const parsed = Number.parseInt(value || '0', 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+// Accumulates request-body bytes and forwards them to the progress manager so
+// SSE clients see incremental transfer progress. Detaches itself when the stream
+// ends, errors, or closes so the listener never outlives the request.
+function attachByteTracker(req, progressManager, uploadId) {
+  let receivedBytes = 0;
+
+  const onData = (chunk) => {
+    if (chunk && chunk.length) {
+      receivedBytes += chunk.length;
+      progressManager.recordReceivedBytes(uploadId, receivedBytes);
+    }
+  };
+
+  const detach = () => {
+    req.off('data', onData);
+    req.off('end', detach);
+    req.off('error', detach);
+    req.off('close', detach);
+  };
+
+  req.on('data', onData);
+  req.on('end', detach);
+  req.on('error', detach);
+  req.on('close', detach);
 }
 
 class FileTypeError extends Error {

--- a/test/upload-progress.test.js
+++ b/test/upload-progress.test.js
@@ -146,6 +146,54 @@ test('uploadId sent as multipart field is tracked after Multer parsing', async (
   assert.equal(snapshot.result.originalName, 'tracked.txt');
 });
 
+function isNonDecreasing(values) {
+  for (let i = 1; i < values.length; i += 1) {
+    if (values[i] < values[i - 1]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+test('streaming upload reports incremental progress via the req data hook', async (t) => {
+  const progressManager = new ProgressManager({
+    initialCleanupMs: 10_000,
+    terminalCleanupMs: 10_000,
+    progressThrottleMs: 0,
+  });
+  const { baseUrl } = await createUploadHarness(t, { progressManager });
+
+  // Capture the progress value carried by every broadcast so we can assert the
+  // sequence the SSE clients would have seen, independent of socket chunking.
+  const captured = [];
+  const originalBroadcast = progressManager.broadcastProgress.bind(progressManager);
+  progressManager.broadcastProgress = (uploadId) => {
+    const snapshot = progressManager.getSnapshot(uploadId);
+    if (snapshot) {
+      captured.push(snapshot.progress);
+    }
+    originalBroadcast(uploadId);
+  };
+
+  const payload = 'x'.repeat(512 * 1024);
+  const { response, body } = await postFiles(`${baseUrl}/api/upload?uploadId=stream-upload`, [
+    { name: 'big.txt', contents: payload },
+  ]);
+
+  assert.equal(response.status, 200);
+  assert.equal(body.errorCode, 0);
+
+  // startUpload emits progress 0; the data hook emits intermediate ticks in
+  // (0, 0.9) as bytes arrive; markProcessing lands 0.9; complete lands 1.
+  const intermediate = captured.filter((value) => value > 0 && value < 0.9);
+  assert.ok(
+    intermediate.length >= 2,
+    `expected >= 2 intermediate progress values in (0, 0.9), got ${intermediate.length}: [${captured.join(', ')}]`,
+  );
+  assert.ok(isNonDecreasing(captured), `progress must be non-decreasing: [${captured.join(', ')}]`);
+  assert.equal(captured[captured.length - 1], 1);
+});
+
 test('progress SSE route stays open and emits lifecycle events', async (t) => {
   const progressManager = new ProgressManager({
     initialCleanupMs: 10_000,


### PR DESCRIPTION
Closes #23

## What
SSE upload progress now animates during transfer instead of jumping 0→0.9→1. A `req` `'data'` listener (attached alongside multer, which keeps the stream in flowing mode) forwards cumulative received bytes to `ProgressManager.recordReceivedBytes`, mapping transfer onto the `[0, 0.9]` band. `markProcessing` still lands `0.9`, `complete` still lands `1`.

## Why
The sole pre-completion update (`markProcessing`) fired *after* multer had already consumed the entire body, so SSE clients only ever saw 0 → 0.9 → 1. This contradicts the per-chunk design documented in `flutter_upload_progress_implementation_plan.md` (committed in the same range as the code) and the "real-time" UI copy in `enhanced-demo-features.md`.

## How
- `ProgressManager.recordReceivedBytes(uploadId, receivedBytes)` — sets `receivedBytes`, computes `progress = clamp(received/fileSize) * networkProgressCeiling`, broadcasts subject to `progressThrottleMs` (default 100 ms, matching the doc; `0` disables for tests). New constructor options `networkProgressCeiling` (default `0.9`) and `progressThrottleMs`. `markProcessing`/`complete` still broadcast unconditionally, so the final `0.9`/`1.0` always land regardless of throttle.
- `progressAwareUploader.attachByteTracker(req, pm, uploadId)` — attaches the `data` listener only when `uploadId` is in the query (the only path that knows the id pre-body); detaches on `end`/`error`/`close`.
- `test/upload-progress.test.js` — integration test posts a ~512 KB file with `query uploadId`, spies on broadcasts, asserts ≥2 intermediate values in `(0, 0.9)`, a non-decreasing sequence, and final `1`.

## Scope / non-goals
- `uploadId` supplied only as a multipart **field** (not query) remains non-streamable: the id is only known after multer parses. Unchanged by design; still reaches `completed`/`progress=1`.
- Unknown `Content-Length` (chunked) leaves `fileSize=0`, so progress stays `0` during transfer — graceful degradation, not required by the design.
- No doc/copy changes: implementing the documented hook makes the existing design doc and UI copy accurate.

## Verification
`npm test` — 17/17 pass, including the new `streaming upload reports incremental progress via the req data hook` (observed ≥2 intermediate values in `(0, 0.9)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)