### PR TITLE
fix: match CORS origin on domain boundary, not raw suffix (#29)

### DIFF
--- a/src/middlewares/browserCors.js
+++ b/src/middlewares/browserCors.js
@@ -5,13 +5,19 @@ function resolveAllowedOrigin(origin, allowedOriginSuffixes = process.env.ALLOWE
     return '';
   }
 
-  const requestOriginWithoutPort = origin.toLowerCase().replace(/:\d+$/, '');
+  const host = origin
+    .toLowerCase()
+    .replace(/^\w+:\/\//, '')
+    .replace(/:\d+$/, '');
   const whitelist = String(allowedOriginSuffixes)
     .split(',')
     .map((suffix) => suffix.trim().toLowerCase())
     .filter(Boolean);
 
-  if (whitelist.some((suffix) => requestOriginWithoutPort.endsWith(suffix))) {
+  // Match on a domain boundary, not a raw string suffix: an origin is admitted
+  // only when its hostname is exactly a whitelist entry or a subdomain of it,
+  // so a distinct registrable domain like evilshukebeta.com is rejected.
+  if (whitelist.some((suffix) => host === suffix || host.endsWith(`.${suffix}`))) {
     return origin;
   }
 

--- a/test/browser-cors.test.js
+++ b/test/browser-cors.test.js
@@ -10,6 +10,23 @@ test('resolveAllowedOrigin accepts localhost with dynamic port', () => {
   assert.equal(resolveAllowedOrigin('http://evil.example.com', 'localhost,shukebeta.com'), '');
 });
 
+test('resolveAllowedOrigin admits only exact hosts and their subdomains', () => {
+  const whitelist = 'localhost,shukebeta.com,shukebeta.eu.org';
+
+  // Exact match and legitimate subdomains are admitted (original origin echoed).
+  assert.equal(resolveAllowedOrigin('https://shukebeta.com', whitelist), 'https://shukebeta.com');
+  assert.equal(resolveAllowedOrigin('https://app.shukebeta.com', whitelist), 'https://app.shukebeta.com');
+  assert.equal(resolveAllowedOrigin('https://sub.shukebeta.eu.org', whitelist), 'https://sub.shukebeta.eu.org');
+  assert.equal(resolveAllowedOrigin('http://localhost', whitelist), 'http://localhost');
+  assert.equal(resolveAllowedOrigin('http://localhost:3000', whitelist), 'http://localhost:3000');
+
+  // Attacker-registrable domains that merely end with a whitelist entry are rejected.
+  assert.equal(resolveAllowedOrigin('https://evilshukebeta.com', whitelist), '');
+  assert.equal(resolveAllowedOrigin('https://notshukebeta.com', whitelist), '');
+  assert.equal(resolveAllowedOrigin('https://xlocalhost', whitelist), '');
+  assert.equal(resolveAllowedOrigin('https://myshukebeta.eu.org', whitelist), '');
+});
+
 test('browser preflight succeeds for whitelisted localhost origin', async (t) => {
   const app = new Koa();
   app.use(createBrowserCorsMiddleware({ allowedOriginSuffixes: 'localhost' }));


### PR DESCRIPTION
Closes #29